### PR TITLE
fix greater thans in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
 ## How to start from the quick start project
 
 - Clone the [jsweet-quickstart](https://github.com/cincheo/jsweet-quickstart) project from Github and import it to your workspace.
-- Right click on your newly added project: `Properties &gt; JSweet &gt; Enable project specific settings`. Set the generated JavaScript folder to `target/js`.
-- Right click on your newly added project: `Configure &gt; Enable JSweet builder`.
+- Right click on your newly added project: `Properties > JSweet > Enable project specific settings`. Set the generated JavaScript folder to `target/js`.
+- Right click on your newly added project: `Configure > Enable JSweet builder`.
 - Clean the project: the `target/js` should be populated.
-- Right-click on `webapp/index.html` and choose `Open with &gt; System editor`. If successful, your browser should popup an alert.
+- Right-click on `webapp/index.html` and choose `Open with > System editor`. If successful, your browser should popup an alert.
 


### PR DESCRIPTION
fix rendering of greater than signs in README.md (because in backticks shouldn't use html style escaping).
